### PR TITLE
fix: update version to 0.0.2 in package.json and index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-gbiz-info",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ModelContext Protocol Gbiz Info",
   "author": "tomiyan",
   "homepage": "https://github.com/tomiyan/mcp-gbiz-info",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ async function featchApi(url: string): Promise<Response> {
 
 const server = new McpServer({
   name: "mcp-gbiz-info",
-  version: "0.0.1",
+  version: "0.0.2",
 });
 
 server.tool(


### PR DESCRIPTION
This pull request includes a version update for the `mcp-gbiz-info` package in both the `package.json` file and the `src/index.ts` file.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.0.1` to `0.0.2`.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L25-R25): Updated the version in the `McpServer` initialization from `0.0.1` to `0.0.2`.